### PR TITLE
Update import path of github_flavored_markdown package.

### DIFF
--- a/api.go
+++ b/api.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 
 	"github.com/gorilla/mux"
-	"github.com/shurcooL/go/github_flavored_markdown"
+	"github.com/shurcooL/github_flavored_markdown"
 )
 
 func DiffHandler(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
It has moved out into a standalone repo recently. See https://github.com/shurcooL/go/issues/19#issuecomment-102574426 for rationale.
